### PR TITLE
add package: lsb-release

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -55,6 +55,7 @@ RUN \
         less \
         libpcre3 \
         libtool \
+        lsb-release \
         m4 \
         parallel \
         pcregrep \


### PR DESCRIPTION
Needed to report the OS version in a portable way, see https://github.com/RIOT-OS/RIOT/pull/10770